### PR TITLE
Update Dockerfile to use lyrionmusicserver version 9.0.4 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/lms-community/lyrionmusicserver:9.0.3
+FROM ghcr.io/lms-community/lyrionmusicserver:9.0.4
 LABEL maintainer="Niklas Dörfler <niklas@doerfler-el.de>"
 
 ENV WAVIN_BACKEND pulse


### PR DESCRIPTION
This pull request updates the base image version in the `Dockerfile` to ensure the application uses the latest features and bug fixes.

Dependency update:

* Changed the base image from `ghcr.io/lms-community/lyrionmusicserver:9.0.3` to `ghcr.io/lms-community/lyrionmusicserver:9.0.4` in `Dockerfile`, upgrading to the newest release.